### PR TITLE
Fixing ws configuration in submission_detail template

### DIFF
--- a/django-data/image/submissions/templates/submissions/submission_detail.html
+++ b/django-data/image/submissions/templates/submissions/submission_detail.html
@@ -188,7 +188,25 @@
   }
 
   var submissionId = {{ submission.pk }};
-  var chatSocket = new WebSocket('ws://' + window.location.host + '/image/ws/submissions/' + submissionId + '/');
+
+  // try to choose the correct protocol, in order to solve the Mixed Content
+  // error when accessing WebSocket server hosted in a different port
+  // https://stackoverflow.com/a/10418013/4385116
+  var loc = window.location, new_uri;
+
+  // check where request come from (which protocol)
+  if (loc.protocol === 'https:') {
+     new_uri = 'wss:';
+  } else {
+     new_uri = 'ws:';
+  }
+
+  // append other elements to the constructed uri
+  new_uri += '//' + loc.host + '/image/ws/submissions/' + submissionId + '/';
+  console.log(new_uri);
+
+  // open the connection through WebSocket
+  var chatSocket = new WebSocket(new_uri);
 
   chatSocket.onmessage = function(e) {
     var data = JSON.parse(e.data);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - .env
 
     # exec a different command from image
-    command: daphne -b 0.0.0.0 -p 8001 --proxy-headers image.asgi:application
+    command: daphne -b 0.0.0.0 -p 8001 --proxy-headers --verbosity 2 image.asgi:application
 
     # set working dir for uwsgi
     working_dir: /var/uwsgi/image/
@@ -97,7 +97,7 @@ services:
 
     # expose a port outside for websocket connections
     ports:
-      - "26081:8001"
+      - "28001:8001"
 
     # link container to database
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,9 @@ services:
         source: ./django-data/
         target: /var/uwsgi/
 
-    # Expose the default port
+    # expose a port outside for websocket connections
+    ports:
+      - "26081:8001"
 
     # link container to database
     links:


### PR DESCRIPTION
This will fix #28 .  I struggled to keep the easiest configuration, but I cannot figure how to forward the ws request to the inner NGINX and daphne server. Inspecting logs, paths were correct, but dapnhe replied with a 404 and this was the final message I found in console log. I don't known if I need to upgrade the connection in the outer proxy, and then reach the inner one. Finally, I decided to expose a different port from docker container, and manage the ws request from the outer NGINX proxy on wp5image. The local development environment remains the same (will be the innner NGINX to solve local connections - no changes in our approach). No more ports are exposed outside from pruduction environment