### PR TITLE
:white_check_mark: cache requests during validation.helpers tests

### DIFF
--- a/django-data/image/validation/tests/test_helpers.py
+++ b/django-data/image/validation/tests/test_helpers.py
@@ -7,12 +7,16 @@ Created on Tue Jan 22 14:28:16 2019
 """
 
 import json
+import redis
+import requests_cache
 
-from image_validation.ValidationResult import (
-    ValidationResultRecord, ValidationResultColumn)
+from datetime import timedelta
+
+from image_validation.ValidationResult import ValidationResultRecord
 from unittest.mock import patch, Mock
 
 from django.test import TestCase
+from django.conf import settings
 
 from image_app.models import Animal, Sample, Submission, Person, Name
 
@@ -22,6 +26,24 @@ from ..helpers import (
     MetaDataValidation, OntologyCacheError, RulesetError)
 from ..models import ValidationResult, ValidationSummary
 from .common import PickableMock, MetaDataValidationTestMixin
+
+# connect to redis database
+connection = redis.StrictRedis(
+    host=settings.REDIS_HOST,
+    port=settings.REDIS_PORT,
+    db=settings.REDIS_DB)
+
+# erase cache after this timedelta
+expire_after = timedelta(days=7)
+
+# start requests-cache
+requests_cache.install_cache(
+    backend='redis',
+    connection=connection,
+    expire_after=expire_after)
+
+# remove expired items
+requests_cache.remove_expired_responses()
 
 
 class MetaDataValidationTestCase(MetaDataValidationTestMixin, TestCase):

--- a/uwsgi/requirements.txt
+++ b/uwsgi/requirements.txt
@@ -5,7 +5,7 @@ channels_redis
 uwsgi
 mysqlclient
 psycopg2-binary
-Django==1.11.21
+django==1.11.22
 ipython
 django-debug-toolbar==1.11
 python-decouple

--- a/uwsgi/requirements.txt
+++ b/uwsgi/requirements.txt
@@ -15,6 +15,7 @@ pytest-django
 pytest-asyncio
 django-widget-tweaks
 requests
+requests_cache
 django-betterforms
 django-registration-redux==2.5
 tornado>=4.2.0,<6.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set up `requests_cache` module during `validation.tests.test_helpers` tests. Request are done once and then stored in *REDIS* database with an expiration times of 7 days, after that cache is invalidated and requests are performed again to update to cache. Cache can be wiped by stopping container and cleaning up *REDIS* volume

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #18 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Every time a test is done, an `image_validation.use_ontology.OntologyCache` object is defined by performing some requests on EBI servers. This is an overhead imposed everytime tests are run. By defining a `request_cache` during tests, we can perform the requests once and then providing cache results. This will increase validation tests performance by caching request of `image_validation` 3rd party module and avoid stress to EBI servers. All other requests should be mocked in order to avoid requests and their cache. This cache is supposed to be valid only on local environment: during *CI* tests we suppose to create a *REDIS* cache from scratch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
code is verified by the same test written before. No changes to the main application, those modifications apply only during tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
