### PR TITLE
:white_check_mark: ensuring submission status before batch update/delete

### DIFF
--- a/django-data/image/common/constants.py
+++ b/django-data/image/common/constants.py
@@ -180,16 +180,10 @@ VALIDATION_MESSAGES_ATTRIBUTES = [
     ['collection_place', 'collection_place_latitude',
      'collection_place_longitude', 'collection_place_accuracy'],
     ['animal_age_at_collection_units', 'animal_age_at_collection'],
-    ['preparation_interval_units', 'preparation_interval'],
-    ['availability'],
-    ['storage'],
-    ['storage_processing'],
-    ['term', 'label'],
-    ['organism_part'],
-    ['developmental_stage'],
-    ['physiological_stage'],
-    ['sex'],
-    ['species'],
+    ['preparation_interval_units', 'preparation_interval',
+     'availability', 'protocol', 'storage', 'storage_processing'],
+    ['organism_part', 'developmental_stage', 'physiological_stage'],
+    ['sex', 'species'],
 ]
 
 UNITS_VALIDATION_MESSAGES = [

--- a/django-data/image/common/helpers.py
+++ b/django-data/image/common/helpers.py
@@ -162,4 +162,6 @@ def uid2biosample(value):
         return 'storage_processing'
     elif value == 'Sampling to preparation interval':
         return 'preparation_interval_units'
+    elif value == 'Specimen collection protocol':
+        return 'protocol'
     return '_'.join(value.lower().split(" "))

--- a/django-data/image/common/tests/test_helpers.py
+++ b/django-data/image/common/tests/test_helpers.py
@@ -149,5 +149,8 @@ class TestUid2Biosample(TestCase):
         test = uid2biosample('Sampling to preparation interval')
         self.assertEqual(test, 'preparation_interval_units')
 
+        test = uid2biosample('Specimen collection protocol')
+        self.assertEqual(test, 'protocol')
+
         test = uid2biosample('meow bark')
         self.assertEqual(test, 'meow_bark')

--- a/django-data/image/submissions/templates/submissions/submission_batch_delete.html
+++ b/django-data/image/submissions/templates/submissions/submission_batch_delete.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <h1>Delete {{ delete_type }} from submission</h1>
-    <form action="{% url 'submissions:batch_delete' pk delete_type %}" method="post">
+    <form method="post">
         {% csrf_token %}
         <div class="form-group">
             <label for="to_delete">Please provide ids to delete (one id per row)</label>

--- a/django-data/image/submissions/templates/submissions/submission_edit.html
+++ b/django-data/image/submissions/templates/submissions/submission_edit.html
@@ -46,7 +46,7 @@
   <p>
     Check my <a href="{% url 'language:species' %}?country={{ submission.gene_bank_country.label|urlencode }}">Species Translation Table</a>
   </p>
-  <p class="container mt-3">
+  <div class="container mt-3">
     <div class="row">
       <div class="col-lg-4 col-md-12 mt-2 text-center">
         <a class="btn btn-primary btn-lg btn-block" href="{% url 'submissions:detail' pk=submission.pk %}" role="button">Back to Submission Detail</a>
@@ -58,7 +58,7 @@
         <a class="btn btn-secondary btn-lg btn-block" href="{% url 'image_app:dashboard' %}" role="button">Return to Dashboard</a>
       </div>
     </div>
-  </p>
+  </div>
 
 {% endblock content %}
 

--- a/django-data/image/submissions/templates/submissions/submission_validation_summary.html
+++ b/django-data/image/submissions/templates/submissions/submission_validation_summary.html
@@ -31,6 +31,20 @@
   <div class="alert-danger">There are no validation results yet!!!</div>
 {% endif %}
 
+<div class="container mt-3">
+  <div class="row">
+    <div class="col-lg-4 col-md-12 mt-2 text-center">
+      <a class="btn btn-primary btn-lg btn-block" href="{% url 'submissions:detail' pk=submission.pk %}" role="button">Back to Submission Detail</a>
+    </div>
+    <div class="col-lg-4 col-md-6 mt-2 text-center">
+      <a class="btn btn-info btn-lg btn-block" href="{% url 'submissions:list' %}" role="button">Back to Submissions List</a>
+    </div>
+    <div class="col-lg-4 col-md-6 mt-2 text-center">
+      <a class="btn btn-secondary btn-lg btn-block" href="{% url 'image_app:dashboard' %}" role="button">Return to Dashboard</a>
+    </div>
+  </div>
+</div>
+
 {% endblock content %}
 
 {% block custom-js %}

--- a/django-data/image/submissions/tests/common.py
+++ b/django-data/image/submissions/tests/common.py
@@ -158,3 +158,5 @@ class SubmissionDataMixin():
 
         # get a submission object
         self.submission = Submission.objects.get(pk=1)
+        self.submission.status = READY
+        self.submission.save()

--- a/django-data/image/submissions/tests/test_view_batch_delete.py
+++ b/django-data/image/submissions/tests/test_view_batch_delete.py
@@ -14,7 +14,7 @@ from django.urls import resolve, reverse
 from common.constants import WAITING
 from common.tests.mixins import GeneralMixinTestCase, OwnerMixinTestCase
 
-from .common import SubmissionDataMixin
+from .common import SubmissionDataMixin, SubmissionStatusMixin
 from ..views import (
     DeleteAnimalsView, DeleteSamplesView, BatchDelete)
 
@@ -83,6 +83,32 @@ class DeleteSamplesViewTest(
 
         link = reverse('submissions:detail', kwargs={'pk': 1})
         self.assertContains(self.response, 'href="{0}"'.format(link))
+
+
+class NoBatchDeleteAnimalTest(
+        SubmissionDataMixin, SubmissionStatusMixin, TestCase):
+    """Test if I can batch delete relying on status"""
+
+    def setUp(self):
+        # call base method
+        super().setUp()
+
+        # explict url (is not a submission:delete view)
+        self.url = reverse('submissions:delete_animals', kwargs={'pk': 1})
+        self.redirect_url = reverse('submissions:detail', kwargs={'pk': 1})
+
+
+class NoBatchDeleteSampleTest(
+        SubmissionDataMixin, SubmissionStatusMixin, TestCase):
+    """Test if I can batch delete relying on status"""
+
+    def setUp(self):
+        # call base method
+        super().setUp()
+
+        # explict url (is not a submission:delete view)
+        self.url = reverse('submissions:delete_samples', kwargs={'pk': 1})
+        self.redirect_url = reverse('submissions:detail', kwargs={'pk': 1})
 
 
 class BatchDeleteMixin(

--- a/django-data/image/submissions/tests/test_view_batch_delete.py
+++ b/django-data/image/submissions/tests/test_view_batch_delete.py
@@ -16,7 +16,7 @@ from common.tests.mixins import GeneralMixinTestCase, OwnerMixinTestCase
 
 from .common import SubmissionDataMixin, SubmissionStatusMixin
 from ..views import (
-    DeleteAnimalsView, DeleteSamplesView, BatchDelete)
+    DeleteAnimalsView, DeleteSamplesView)
 
 
 class DeleteAnimalsViewTest(
@@ -174,9 +174,7 @@ class SuccessfulDeleteAnimalsViewTest(
         self.batch_delete = self.batch_delete_patcher.start()
 
         # explict url (is not a submission:delete view)
-        self.url = reverse(
-            'submissions:batch_delete',
-            kwargs={'pk': 1, 'type': 'Animals'})
+        self.url = reverse('submissions:delete_animals', kwargs={'pk': 1})
 
         self.data = {'to_delete': 'ANIMAL:::ID:::132713'}
 
@@ -186,10 +184,6 @@ class SuccessfulDeleteAnimalsViewTest(
             self.data,
             follow=True
         )
-
-    def test_url_resolves_view(self):
-        view = resolve('/submissions/1/batch_delete/Animals/')
-        self.assertIsInstance(view.func.view_class(), BatchDelete)
 
 
 class SuccessfulDeleteSamplesViewTest(
@@ -207,9 +201,7 @@ class SuccessfulDeleteSamplesViewTest(
         self.batch_delete = self.batch_delete_patcher.start()
 
         # explict url (is not a submission:delete view)
-        self.url = reverse(
-            'submissions:batch_delete',
-            kwargs={'pk': 1, 'type': 'Samples'})
+        self.url = reverse('submissions:delete_samples', kwargs={'pk': 1})
 
         self.data = {'to_delete': 'Siems_0722_393449'}
 
@@ -219,7 +211,3 @@ class SuccessfulDeleteSamplesViewTest(
             self.data,
             follow=True
         )
-
-    def test_url_resolves_view(self):
-        view = resolve('/submissions/1/batch_delete/Samples/')
-        self.assertIsInstance(view.func.view_class(), BatchDelete)

--- a/django-data/image/submissions/tests/test_view_batch_update.py
+++ b/django-data/image/submissions/tests/test_view_batch_update.py
@@ -15,27 +15,17 @@ from common.constants import WAITING
 from common.tests import GeneralMixinTestCase, OwnerMixinTestCase
 from validation.models import ValidationSummary
 
-from .common import SubmissionDataMixin
+from .common import SubmissionDataMixin, SubmissionStatusMixin
 from ..views import SubmissionValidationSummaryFixErrorsView, FixValidation
 
 
 class SubmissionValidationSummaryFixErrorsViewTest(
-        GeneralMixinTestCase, OwnerMixinTestCase, TestCase):
+        SubmissionDataMixin, GeneralMixinTestCase, OwnerMixinTestCase,
+        TestCase):
     """Test SubmissionValidationSummaryViewTest View"""
 
-    fixtures = [
-        "image_app/user",
-        "image_app/dictcountry",
-        "image_app/dictrole",
-        "image_app/organization",
-        "image_app/submission",
-        "validation/validationsummary"
-    ]
-
     def setUp(self):
-        # login a test user (defined in fixture)
-        self.client = Client()
-        self.client.login(username='test', password='test')
+        super().setUp()
 
         self.url = reverse(
             'submissions:validation_summary_fix_errors',
@@ -67,9 +57,8 @@ class SubmissionValidationSummaryFixErrorsViewColumnTest(
         SubmissionDataMixin, TestCase):
 
     def setUp(self):
-        # login a test user (defined in fixture)
-        self.client = Client()
-        self.client.login(username='test', password='test')
+        # calling minxin methods
+        super().setUp()
 
         self.url_animal = reverse(
             'submissions:validation_summary_fix_errors',
@@ -149,6 +138,24 @@ class SubmissionValidationSummaryFixErrorsViewColumnTest(
         # get animal page
         response = self.client.get(self.url_sample)
         self.assertEqual(response.status_code, 200)
+
+
+class NoBatchUpdateTest(
+        SubmissionDataMixin, SubmissionStatusMixin, TestCase):
+    """Test if I can batch delete relying on status"""
+
+    def setUp(self):
+        # call base method
+        super().setUp()
+
+        # explict url (is not a submission:delete view)
+        self.url = reverse(
+            'submissions:validation_summary_fix_errors',
+            kwargs={
+                'pk': 1,
+                'type': 'animal',
+                'message_counter': 0})
+        self.redirect_url = reverse('submissions:detail', kwargs={'pk': 1})
 
 
 class FixValidationMixin(

--- a/django-data/image/submissions/urls.py
+++ b/django-data/image/submissions/urls.py
@@ -56,8 +56,4 @@ urlpatterns = [
         r'(?P<attribute_to_edit>[\w]+)/$',
         views.FixValidation.as_view(),
         name='fix_validation'),
-
-    url(r'^(?P<pk>[-\w]+)/batch_delete/(?P<type>[\w]+)/$',
-        views.BatchDelete.as_view(),
-        name='batch_delete')
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small refactor and checking submission status before a batch operation

## Description
<!--- Describe your changes in detail -->
It addresses some issues of #16; The other points seem to be complicated and need to be modeled as separate PR

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #16 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It will solve some issues of #16 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
code has been tested using unittest and working with the application

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
