### PR TITLE
:bug: catch errors when creating a biosample user

### DIFF
--- a/django-data/image/biosample/views.py
+++ b/django-data/image/biosample/views.py
@@ -294,6 +294,28 @@ class CreateUserView(LoginRequiredMixin, RegisterMixin, MyFormMixin, FormView):
     form_class = CreateUserForm
     success_url_message = "Account created"
 
+    def deal_with_errors(self, error_message, exception):
+        """Add messages to view for encountered errors
+
+        Args:
+            error_message (str): An informative text
+            exception (Exception): an exception instance
+        """
+
+        exception_message = "Message was: %s" % (exception)
+
+        logger.error(error_message)
+        logger.error(exception_message)
+
+        messages.error(
+            self.request,
+            message=error_message,
+            extra_tags="alert alert-dismissible alert-danger")
+        messages.error(
+            self.request,
+            message=exception_message,
+            extra_tags="alert alert-dismissible alert-danger")
+
     def get_form_kwargs(self):
         """Override get_form_kwargs"""
 
@@ -307,10 +329,18 @@ class CreateUserView(LoginRequiredMixin, RegisterMixin, MyFormMixin, FormView):
 
         return kwargs
 
-    # HINT: move to a celery task?
-    def form_valid(self, form):
-        """Create a new team in with biosample manager user, then create a new
-        user and register it"""
+    # create an user or throw an exception
+    def create_biosample_user(self, form, full_name, affiliation):
+        """Create a biosample user
+
+        Args:
+            form (:py:class:`CreateUserForm`) an instantiated form object
+            full_name (str): the user full name (Name + Surname)
+            affiliation (str): the organization the user belongs to
+
+        Returns:
+            str: a biosamples user id
+        """
 
         password = form.cleaned_data['password1']
         confirmPwd = form.cleaned_data['password2']
@@ -318,21 +348,16 @@ class CreateUserView(LoginRequiredMixin, RegisterMixin, MyFormMixin, FormView):
         # get user model associated with this session
         user = self.request.user
 
-        first_name = user.first_name
-        last_name = user.last_name
+        # get email
         email = user.email
 
-        # Affiliation is the institution the user belong
-        affiliation = user.person.affiliation.name
-
-        # set full name as
-        full_name = " ".join([first_name, last_name])
+        biosample_user_id = None
 
         # creating a user
         logger.debug("Creating user %s" % (form.username))
 
         try:
-            user_id = User.create_user(
+            biosample_user_id = User.create_user(
                 user=form.username,
                 password=password,
                 confirmPwd=confirmPwd,
@@ -341,21 +366,25 @@ class CreateUserView(LoginRequiredMixin, RegisterMixin, MyFormMixin, FormView):
                 organisation=affiliation
             )
 
+            logger.info("user_id %s generated" % (biosample_user_id))
+
         except ConnectionError as e:
-            logger.error("Problem in creating user %s" % (form.username))
-            logger.error("Message was: %s" % (e))
-            messages.error(
-                self.request,
-                message="Problem in creating user %s",
-                extra_tags="alert alert-dismissible alert-danger")
+            message = "Problem in creating user %s" % (form.username)
+            self.deal_with_errors(message, e)
 
-            messages.error(
-                self.request,
-                message="Message was: %s" % (e),
-                extra_tags="alert alert-dismissible alert-danger")
+        return biosample_user_id
 
-            # return invalid form
-            return self.form_invalid(form)
+    def create_biosample_team(self, full_name, affiliation):
+        """Create a biosample team
+
+        Args:
+            full_name (str): the user full name (Name + Surname)
+            affiliation (str): the organization the user belongs to
+
+        Returns:
+            :py:class:`pyUSIrest.client.Team`: a pyUSIrest Team instance
+            :py:class:`biosample.models.ManagedTeam`: a model object
+        """
 
         # creating a new team. First create an user object
         # create a new auth object
@@ -367,20 +396,34 @@ class CreateUserView(LoginRequiredMixin, RegisterMixin, MyFormMixin, FormView):
 
         description = "Team for %s" % (full_name)
 
+        # the values I want to return
+        team, managed_team = None, None
+
         # now create a team
         logger.debug("Creating team for %s" % (full_name))
-        team = admin.create_team(
-            description=description,
-            centreName=affiliation)
 
-        logger.info("Team %s generated" % (team.name))
+        try:
 
-        # register team in ManagedTeam table
-        managed, created = ManagedTeam.objects.get_or_create(
-            name=team.name)
+            team = admin.create_team(
+                description=description,
+                centreName=affiliation)
 
-        if created is True:
-            logger.info("Created: %s" % (managed))
+            logger.info("Team %s generated" % (team.name))
+
+            # register team in ManagedTeam table
+            managed_team, created = ManagedTeam.objects.get_or_create(
+                name=team.name)
+
+            if created is True:
+                logger.info("Created: %s" % (managed_team))
+
+        except ConnectionError as e:
+            message = "Problem in creating team for %s" % (full_name)
+            self.deal_with_errors(message, e)
+
+        return team, managed_team
+
+    def add_biosample_user_to_team(self, form, user_id, team, managed_team):
 
         # I need to generate a new token to see the new team
         logger.debug("Generate a new token for 'USI_MANAGER'")
@@ -397,26 +440,87 @@ class CreateUserView(LoginRequiredMixin, RegisterMixin, MyFormMixin, FormView):
         domain = admin.get_domain_by_name(team.name)
         domain_id = domain.domainReference
 
+        # the value I want to return
+        account = None
+
         logger.debug(
             "Adding user %s to team %s" % (form.username, team.name))
 
-        # user to team
-        admin.add_user_to_team(user_id=user_id, domain_id=domain_id)
+        try:
+            # user to team
+            admin.add_user_to_team(user_id=user_id, domain_id=domain_id)
 
-        # save objects in accounts table
-        account = Account.objects.create(
-            user=self.request.user,
-            name=form.username,
-            team=managed
-        )
+            # save objects in accounts table
+            account = Account.objects.create(
+                user=self.request.user,
+                name=form.username,
+                team=managed_team
+            )
 
-        logger.info("%s created" % (account))
+            logger.info("%s created" % (account))
 
-        # add message
-        messages.debug(
-            request=self.request,
-            message="User %s added to team %s" % (form.username, team.name),
-            extra_tags="alert alert-dismissible alert-light")
+            # add message
+            messages.debug(
+                request=self.request,
+                message="User %s added to team %s" % (
+                    form.username, team.name),
+                extra_tags="alert alert-dismissible alert-light")
+
+        except ConnectionError as e:
+            message = "Problem in adding user %s to team %s" % (
+                form.username, team.name)
+            self.deal_with_errors(message, e)
+
+        return account
+
+    # HINT: move to a celery task?
+    def form_valid(self, form):
+        """Create a new team in with biosample manager user, then create a new
+        user and register it"""
+
+        # get user model associated with this session
+        user = self.request.user
+
+        # get user info
+        first_name = user.first_name
+        last_name = user.last_name
+
+        # set full name as
+        full_name = " ".join([first_name, last_name])
+
+        # Affiliation is the institution the user belong
+        affiliation = user.person.affiliation.name
+
+        # model generic errors from EBI API endpoints
+        try:
+            user_id = self.create_biosample_user(form, full_name, affiliation)
+
+            if user_id is None:
+                # return invalid form
+                return self.form_invalid(form)
+
+            # create a biosample team
+            team, managed_team = self.create_biosample_team(
+                full_name, affiliation)
+
+            if team is None:
+                # return invalid form
+                return self.form_invalid(form)
+
+            account = self.add_biosample_user_to_team(
+                form, user_id, team, managed_team)
+
+            if account is None:
+                # return invalid form
+                return self.form_invalid(form)
+
+        except ConnectionError as e:
+            message = (
+                "Problem with EBI-AAP endoints. Please contact IMAGE team")
+            self.deal_with_errors(message, e)
+
+            # return invalid form
+            return self.form_invalid(form)
 
         # call to a inherited function (which does an HttpResponseRedirect
         # to success_url)

--- a/django-data/image/biosample/views.py
+++ b/django-data/image/biosample/views.py
@@ -2,6 +2,7 @@
 import os
 import redis
 import logging
+import traceback
 
 from decouple import AutoConfig
 
@@ -20,6 +21,7 @@ from django.http import HttpResponseRedirect
 from pyUSIrest.client import User
 
 from common.constants import WAITING
+from common.helpers import send_mail_to_admins
 from image_app.models import Submission
 
 from .forms import (
@@ -311,10 +313,17 @@ class CreateUserView(LoginRequiredMixin, RegisterMixin, MyFormMixin, FormView):
             self.request,
             message=error_message,
             extra_tags="alert alert-dismissible alert-danger")
+
         messages.error(
             self.request,
             message=exception_message,
             extra_tags="alert alert-dismissible alert-danger")
+
+        # get exception info
+        einfo = traceback.format_exc()
+
+        # send a mail to admin
+        send_mail_to_admins(error_message, einfo)
 
     def get_form_kwargs(self):
         """Override get_form_kwargs"""

--- a/django-data/image/common/helpers.py
+++ b/django-data/image/common/helpers.py
@@ -17,6 +17,7 @@ from dateutil.relativedelta import relativedelta
 
 from django.conf import settings
 from django.contrib.admin.utils import NestedObjects
+from django.core.mail import send_mass_mail
 from django.db import DEFAULT_DB_ALIAS
 from django.utils.text import capfirst
 from django.utils.encoding import force_text
@@ -153,6 +154,29 @@ def get_admin_emails():
 
     # return all admin mail addresses
     return [admin[1] for admin in ADMINS]
+
+
+def send_mail_to_admins(
+        email_subject, email_message,
+        default_from=settings.DEFAULT_FROM_EMAIL,
+        addresses=get_admin_emails()):
+    """Send a mail to all admins
+
+    Args:
+        email_subject (str): the email subject
+        email_message (str): the body of the email
+        default_from (str): the from field of the email
+        addresses (list): a list of email addresses
+    """
+
+    # submit mail to admins
+    datatuple = (
+        email_subject,
+        email_message,
+        default_from,
+        addresses)
+
+    send_mass_mail((datatuple, ))
 
 
 def uid2biosample(value):

--- a/django-data/image/common/tests/test_helpers.py
+++ b/django-data/image/common/tests/test_helpers.py
@@ -8,12 +8,13 @@ Created on Wed Mar 27 14:35:36 2019
 
 from django.test import TestCase
 from django.utils.dateparse import parse_date
+from django.core import mail
 from django.core.validators import validate_email
 
 from .. import constants
 from ..helpers import (
     format_attribute, get_admin_emails, image_timedelta, parse_image_timedelta,
-    uid2biosample)
+    uid2biosample, send_mail_to_admins)
 
 
 class TestImageTimedelta(TestCase):
@@ -129,12 +130,27 @@ class TestAttributes(TestCase):
 
 class TestAdminEmails(TestCase):
 
-    def test_admin_emails(self):
-        # calling objects
-        emails = get_admin_emails()
+    def setUp(self):
+        # tracking admin emails
+        self.admin_emails = get_admin_emails()
 
-        for email in emails:
+    def test_admin_emails(self):
+        """Test admin emails are valid"""
+
+        for email in self.admin_emails:
             self.assertIsNone(validate_email(email))
+
+    def test_send_mail_to_admins(self):
+        """Test mails sent to admin"""
+
+        # sending mails
+        send_mail_to_admins("subject", "body")
+
+        # checking messages
+        email = mail.outbox[0]
+        self.assertEqual(email.subject, "subject")
+        self.assertEqual(email.body, "body")
+        self.assertEqual(email.to, self.admin_emails)
 
 
 class TestUid2Biosample(TestCase):

--- a/django-data/image/image/settings.py
+++ b/django-data/image/image/settings.py
@@ -27,7 +27,9 @@ SECRET_KEY = config('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', cast=bool, default=False)
 
-ADMINS = [('Admin', 'bioinfo.ibba@gmail.com'), ]
+ADMINS = [
+    ('Admin', 'bioinfo.ibba@gmail.com'),
+    ('Paolo Cozzi', 'paolo.cozzi@ibba.cnr.it')]
 
 ALLOWED_HOSTS = ['*']
 

--- a/django-data/image/validation/tasks.py
+++ b/django-data/image/validation/tasks.py
@@ -20,7 +20,7 @@ from django.core.mail import send_mass_mail
 
 from common.constants import (
     READY, ERROR, LOADED, NEED_REVISION, COMPLETED, STATUSES, KNOWN_STATUSES)
-from common.helpers import get_admin_emails
+from common.helpers import send_mail_to_admins
 from image.celery import app as celery_app, MyTask
 from image_app.models import Submission, Sample, Animal
 from submissions.helpers import send_message
@@ -350,16 +350,10 @@ class ValidateTask(MyTask):
             email_message,
         )
 
-        # TODO: should this be a common.helpers method?
+        # this is a common.helpers method that should be used when needed
         if notify_admins:
             # submit mail to admins
-            datatuple = (
-                email_subject,
-                email_message,
-                settings.DEFAULT_FROM_EMAIL,
-                get_admin_emails())
-
-            send_mass_mail((datatuple, ))
+            send_mail_to_admins(email_subject, email_message)
 
     # Ovverride default on failure method
     # This is not a failed validation for a wrong value, this is an

--- a/django-data/image/validation/tasks.py
+++ b/django-data/image/validation/tasks.py
@@ -15,9 +15,6 @@ import traceback
 from collections import Counter, defaultdict
 from celery.utils.log import get_task_logger
 
-from django.conf import settings
-from django.core.mail import send_mass_mail
-
 from common.constants import (
     READY, ERROR, LOADED, NEED_REVISION, COMPLETED, STATUSES, KNOWN_STATUSES)
 from common.helpers import send_mail_to_admins

--- a/uwsgi/requirements.txt
+++ b/uwsgi/requirements.txt
@@ -30,7 +30,7 @@ python-magic
 python-dateutil
 django-simple-cookie-consent==0.1.1
 xlrd
-# git+https://github.com/cnr-ibba/pyUSIrest.git@b07c54830d57603ba052821b43ad36e11bdab62c
-pyUSIrest==0.2.2
+git+https://github.com/cnr-ibba/pyUSIrest.git@6ae3d0d5e87a772e1ec861623c9eb117c446344c
+# pyUSIrest==0.2.2
 git+https://github.com/cnr-ibba/IMAGE-ValidationTool.git@a335e7fd9317c38bf345255c6ddec71d627c59d7
 sphinx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Catch errors when creating a biosample user

## Description
<!--- Describe your changes in detail -->
If there are issues from Biosample API when creating a user, I will return a form invalid and a message to users/and amins. More infor are available in issue #52 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #52 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to return a user a more useful page instead of *500 internal server error*

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with unittest

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
