### PR TITLE
:bug: template path raises form.ValidationError for text files

### DIFF
--- a/django-data/image/submissions/forms.py
+++ b/django-data/image/submissions/forms.py
@@ -80,7 +80,14 @@ class SubmissionFormMixin():
 
         uploaded_file = self.cleaned_data['uploaded_file']
 
-        # xlrd can manage onli files. Write a temporary file
+        chunk = next(uploaded_file.chunks())
+        magic_line = magic.from_buffer(chunk)
+
+        if 'Microsoft' not in magic_line:
+            msg = "The file you provided is not a Template file"
+            raise forms.ValidationError(msg, code='invalid')
+
+        # xlrd can manage only files. Write a temporary file
         with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
             for chunk in uploaded_file.chunks():
                 tmpfile.write(chunk)

--- a/django-data/image/submissions/tests/test_view_new_submission.py
+++ b/django-data/image/submissions/tests/test_view_new_submission.py
@@ -204,7 +204,7 @@ class SupportedCreateSubmissionViewTest(Initialize):
     # patch to simulate data load
     @patch('submissions.views.ImportCRBAnimTask.delay')
     def test_crb_anim_loading(self, my_task):
-        # submit a cryoweb like dictionary
+        # submit a crbanim like dictionary
         self.file_loading(my_task, CRB_ANIM_TYPE)
 
     @patch('submissions.views.ImportTemplateTask.delay')
@@ -273,3 +273,23 @@ class IssuesWithFilesTest(Initialize):
 
         # check errors
         self.common_check(response, my_task)
+
+    @patch('submissions.views.ImportCRBAnimTask.delay')
+    @patch('submissions.views.ImportTemplateTask.delay')
+    def test_template_issues_in_file(self, my_task, my_crbanim):
+        # get data for CRB_ANIM
+        data = self.get_data(ds_file=CRB_ANIM_TYPE)
+
+        # override datasource type
+        data['datasource_type'] = TEMPLATE_TYPE
+
+        # submit a template file with a CRBanim
+        response = self.client.post(
+            self.url,
+            data)
+
+        # check errors and assert my_task not called
+        self.common_check(response, my_task)
+
+        # assert not calling also CRBanim
+        self.assertFalse(my_crbanim.called)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We prevent to upload text file using the template type when creating/reloading a submission

## Description
<!--- Describe your changes in detail -->
problem is described in #54 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Put closes #XXXX in your comment to auto-close the issue that your -->
<!--- PR fixes (if such).Please link to the issue here: -->
closes #54 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to avoid the *500 Internal Server Error* when uploading a text file using the template format

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code has been tested with unittest and by using InjectTool to upload text data using Template datasource

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which improve code itself)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
